### PR TITLE
refactor: change SPDXExpression to not parse immediately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `SPDXExpression::new` for creating expressions without parsing them. The expression is stored
+  as a plain `String`.
+- Add `SPDXExpression::expression` for parsing the stored `String` to an expression.
+
+### Removed
+
+- **Breaking:** Remove `SPDXExpression::parse`. The `SPDXExpression` is not parsed at creation, but
+  when the expression in parsed format is needed.
+
+### Changed
+
+- **Breaking:** Change `SPDXExpression::licenses` to return `Result` as parsing can fail.
+
 ## [0.3.0] - 2021-10-21
 
 ### Changed

--- a/src/models/file_information.rs
+++ b/src/models/file_information.rs
@@ -79,7 +79,7 @@ impl Default for FileInformation {
             file_spdx_identifier: "NOASSERTION".to_string(),
             file_type: Vec::new(),
             file_checksum: Vec::new(),
-            concluded_license: SPDXExpression::parse("NOASSERTION").unwrap(),
+            concluded_license: SPDXExpression::new("NOASSERTION"),
             license_information_in_file: Vec::new(),
             comments_on_license: None,
             copyright_text: "NOASSERTION".to_string(),
@@ -240,7 +240,7 @@ mod test {
         .unwrap();
         assert_eq!(
             spdx.file_information[0].concluded_license,
-            SPDXExpression::parse("Apache-2.0").unwrap()
+            SPDXExpression::new("Apache-2.0")
         );
     }
     #[test]

--- a/src/models/package_information.rs
+++ b/src/models/package_information.rs
@@ -158,9 +158,9 @@ impl Default for PackageInformation {
             package_checksum: Vec::new(),
             package_home_page: None,
             source_information: None,
-            concluded_license: SPDXExpression::parse("NOASSERTION").unwrap(),
+            concluded_license: SPDXExpression::default(),
             all_licenses_information_from_files: Vec::new(),
-            declared_license: SPDXExpression::parse("NOASSERTION").unwrap(),
+            declared_license: SPDXExpression::default(),
             comments_on_license: None,
             copyright_text: "NOASSERTION".to_string(),
             package_summary_description: None,
@@ -432,7 +432,7 @@ mod test {
         .unwrap();
         assert_eq!(
             spdx.package_information[0].concluded_license,
-            SPDXExpression::parse("(LGPL-2.0-only OR LicenseRef-3)").unwrap()
+            SPDXExpression::new("(LGPL-2.0-only OR LicenseRef-3)")
         );
     }
     #[test]
@@ -459,7 +459,7 @@ mod test {
         .unwrap();
         assert_eq!(
             spdx.package_information[0].declared_license,
-            SPDXExpression::parse("(LGPL-2.0-only AND LicenseRef-3)").unwrap()
+            SPDXExpression::new("(LGPL-2.0-only AND LicenseRef-3)")
         );
     }
     #[test]

--- a/src/models/snippet.rs
+++ b/src/models/snippet.rs
@@ -177,7 +177,7 @@ mod test {
         .unwrap();
         assert_eq!(
             spdx.snippet_information[0].snippet_concluded_license,
-            SPDXExpression::parse("GPL-2.0-only").unwrap()
+            SPDXExpression::new("GPL-2.0-only")
         );
     }
     #[test]

--- a/src/models/spdx_document.rs
+++ b/src/models/spdx_document.rs
@@ -157,7 +157,7 @@ impl SPDX {
         let mut license_ids = Vec::new();
 
         for file in &self.file_information {
-            for license in &file.concluded_license.licenses() {
+            for license in &file.concluded_license.licenses()? {
                 if !license_ids.contains(license) && license != "NOASSERTION" && license != "NONE" {
                     license_ids.push(license.clone());
                 }
@@ -228,7 +228,7 @@ mod test {
 
         assert_eq!(
             file.0.concluded_license,
-            SPDXExpression::parse("LicenseRef-1").unwrap()
+            SPDXExpression::new("LicenseRef-1")
         );
     }
 

--- a/src/models/spdx_document.rs
+++ b/src/models/spdx_document.rs
@@ -89,7 +89,7 @@ impl SPDX {
                 document_name: name.to_string(),
                 spdx_document_namespace: format!(
                     "http://spdx.org/spdxdocs/{}-{}",
-                    name.to_string(),
+                    name,
                     Uuid::new_v4()
                 ),
                 ..DocumentCreationInformation::default()

--- a/src/models/spdx_expression.rs
+++ b/src/models/spdx_expression.rs
@@ -4,47 +4,51 @@
 
 use std::ops::{Deref, DerefMut};
 
-use serde::{
-    de::{Unexpected, Visitor},
-    Deserialize, Serialize,
-};
+use serde::{Deserialize, Serialize};
 use spdx::Expression;
 
 use crate::error::SpdxError;
 
 /// <https://spdx.github.io/spdx-spec/appendix-IV-SPDX-license-expressions/>
-#[derive(PartialEq, Debug, Clone)]
-pub struct SPDXExpression(Expression);
+#[derive(PartialEq, Debug, Clone, Serialize, Deserialize)]
+pub struct SPDXExpression(String);
 
 impl Default for SPDXExpression {
     fn default() -> Self {
-        Self(Expression::parse("NOASSERTION").expect("This will always succeed."))
+        Self::new("NOASSERTION")
     }
 }
 
 impl SPDXExpression {
+    /// Create a new `SPDXExpression`. Does not check for the validity of the expression, all
+    /// strings will succeed.
+    pub fn new(expression: &str) -> Self {
+        Self(expression.to_string())
+    }
+
     /// # Errors
     ///
     /// Returns [`SpdxError`] if parsing of the epxression fails.
-    pub fn parse(expression: &str) -> Result<Self, SpdxError> {
-        Ok(Self(Expression::parse(expression).map_err(|_err| {
-            SpdxError::Parse("Error parsing SPDX".into())
-        })?))
+    pub fn expression(&self) -> Result<Expression, SpdxError> {
+        Expression::parse(&self.0).map_err(|err| SpdxError::Parse(err.to_string()))
     }
+
     /// Get licenses from the expression.
     ///
     /// # Errors
     ///
     /// Returns [`SpdxError`] if parsing of the epxression fails.
-    pub fn licenses(&self) -> Vec<String> {
-        self.requirements()
+    pub fn licenses(&self) -> Result<Vec<String>, SpdxError> {
+        Ok(self
+            .expression()?
+            .requirements()
             .map(|req| req.req.to_string())
-            .collect::<Vec<_>>()
+            .collect::<Vec<_>>())
     }
 }
 
 impl Deref for SPDXExpression {
-    type Target = Expression;
+    type Target = String;
 
     fn deref(&self) -> &Self::Target {
         &self.0
@@ -57,51 +61,15 @@ impl DerefMut for SPDXExpression {
     }
 }
 
-struct SPDXExpressionVisitor;
-
-impl<'de> Visitor<'de> for SPDXExpressionVisitor {
-    type Value = SPDXExpression;
-
-    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-        formatter.write_str("a valid SPDX Expression string")
-    }
-
-    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-    where
-        E: serde::de::Error,
-    {
-        SPDXExpression::parse(v).map_err(|_err| E::invalid_value(Unexpected::Str(v), &self))
-    }
-}
-
-impl Serialize for SPDXExpression {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        serializer.serialize_str(&self.to_string())
-    }
-}
-
-impl<'de> Deserialize<'de> for SPDXExpression {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        deserializer.deserialize_str(SPDXExpressionVisitor)
-    }
-}
-
 #[cfg(test)]
 mod test_spdx_expression {
     use super::*;
 
     #[test]
     fn get_separated_licenses() {
-        let input_1 = SPDXExpression::parse("MIT OR GPL-2.0-or-later").unwrap();
-        let input_2 = SPDXExpression::parse("MIT OR (GPL-2.0-or-later AND ISC)").unwrap();
-        let input_3 =
-            SPDXExpression::parse("MIT AND (GPL-2.0-or-later AND ISC) AND BSD-3-Clause").unwrap();
+        let input_1 = SPDXExpression::new("MIT OR GPL-2.0-or-later");
+        let input_2 = SPDXExpression::new("MIT OR (GPL-2.0-or-later AND ISC)");
+        let input_3 = SPDXExpression::new("MIT AND (GPL-2.0-or-later AND ISC) AND BSD-3-Clause");
 
         let mut expected_1 = vec!["MIT".to_string(), "GPL-2.0-or-later".to_string()];
         let mut expected_2 = vec![
@@ -116,9 +84,9 @@ mod test_spdx_expression {
             "BSD-3-Clause".to_string(),
         ];
 
-        let mut actual_1 = input_1.licenses();
-        let mut actual_2 = input_2.licenses();
-        let mut actual_3 = input_3.licenses();
+        let mut actual_1 = input_1.licenses().unwrap();
+        let mut actual_2 = input_2.licenses().unwrap();
+        let mut actual_3 = input_3.licenses().unwrap();
 
         expected_1.sort();
         expected_2.sort();

--- a/src/parsers/mod.rs
+++ b/src/parsers/mod.rs
@@ -349,7 +349,7 @@ fn process_atom_for_packages(
         }
         Atom::PackageLicenseConcluded(value) => {
             if let Some(package) = &mut package_in_progress {
-                package.concluded_license = SPDXExpression::parse(value)?;
+                package.concluded_license = SPDXExpression::new(value);
             }
         }
         Atom::PackageLicenseInfoFromFiles(value) => {
@@ -361,7 +361,7 @@ fn process_atom_for_packages(
         }
         Atom::PackageLicenseDeclared(value) => {
             if let Some(package) = &mut package_in_progress {
-                package.declared_license = SPDXExpression::parse(value)?;
+                package.declared_license = SPDXExpression::new(value);
             }
         }
         Atom::PackageLicenseComments(value) => {
@@ -462,7 +462,7 @@ fn process_atom_for_files(
         }
         Atom::LicenseConcluded(value) => {
             if let Some(file) = &mut file_in_progress {
-                file.concluded_license = SPDXExpression::parse(value)?;
+                file.concluded_license = SPDXExpression::new(value);
             }
         }
         Atom::LicenseInfoInFile(value) => {
@@ -534,7 +534,7 @@ fn process_atom_for_snippets(
         }
         Atom::SnippetLicenseConcluded(value) => {
             if let Some(snippet) = &mut snippet_in_progress {
-                snippet.snippet_concluded_license = SPDXExpression::parse(value)?;
+                snippet.snippet_concluded_license = SPDXExpression::new(value);
             }
         }
         Atom::LicenseInfoInSnippet(value) => {
@@ -856,6 +856,8 @@ compatible system run time libraries."
         assert_eq!(
             glibc
                 .concluded_license
+                .expression()
+                .unwrap()
                 .requirements()
                 .map(|er| er.req.license.id())
                 .collect::<Vec<_>>(),
@@ -871,6 +873,8 @@ compatible system run time libraries."
         assert_eq!(
             glibc
                 .declared_license
+                .expression()
+                .unwrap()
                 .requirements()
                 .map(|er| er.req.license.id())
                 .collect::<Vec<_>>(),
@@ -944,6 +948,8 @@ This information was found in the COPYING.txt file in the xyz directory.".to_str
         );
         assert_eq!(
             fooc.concluded_license
+                .expression()
+                .unwrap()
                 .requirements()
                 .map(|er| er.req.license.id())
                 .collect::<Vec<_>>(),
@@ -1019,7 +1025,7 @@ THE SOFTWARE IS PROVIDED �AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMP
             .any(|snip| snip.end_pointer == Pointer::new_line(None, 23)));
         assert_eq!(
             snippet.snippet_concluded_license,
-            SPDXExpression::parse("GPL-2.0-only").unwrap()
+            SPDXExpression::new("GPL-2.0-only")
         );
         assert_eq!(snippet.license_information_in_snippet, vec!["GPL-2.0-only"]);
         assert_eq!(snippet.snippet_comments_on_license, Some("The concluded license was taken from package xyz, from which the snippet was copied into the current file. The concluded license information was found in the COPYING.txt file in package xyz.".to_string()));

--- a/src/parsers/mod.rs
+++ b/src/parsers/mod.rs
@@ -634,10 +634,10 @@ fn process_annotation(
 
 fn process_atom_for_annotations(
     atom: &Atom,
-    mut annotations: &mut Vec<Annotation>,
+    annotations: &mut Vec<Annotation>,
     mut annotation_in_progress: &mut AnnotationInProgress,
 ) -> Result<(), SpdxError> {
-    process_annotation(annotation_in_progress, &mut annotations);
+    process_annotation(annotation_in_progress, annotations);
 
     match atom {
         Atom::Annotator(value) => {

--- a/src/parsers/mod.rs
+++ b/src/parsers/mod.rs
@@ -113,16 +113,16 @@ fn spdx_from_atoms(atoms: &[Atom]) -> Result<SPDX, SpdxError> {
             &mut package_information,
             &mut package_in_progress,
             &mut external_package_ref_in_progress,
-        )?;
+        );
         process_atom_for_files(
             atom,
             &mut file_in_progress,
             &mut file_information,
             &package_in_progress,
             &mut relationships,
-        )?;
-        process_atom_for_snippets(atom, &mut snippet_information, &mut snippet_in_progress)?;
-        process_atom_for_relationships(atom, &mut relationships, &mut relationship_in_progress)?;
+        );
+        process_atom_for_snippets(atom, &mut snippet_information, &mut snippet_in_progress);
+        process_atom_for_relationships(atom, &mut relationships, &mut relationship_in_progress);
         process_atom_for_annotations(atom, &mut annotations, &mut annotation_in_progress)?;
         process_atom_for_license_info(
             atom,
@@ -279,7 +279,7 @@ fn process_atom_for_packages(
     packages: &mut Vec<PackageInformation>,
     mut package_in_progress: &mut Option<PackageInformation>,
     mut external_package_ref_in_progress: &mut Option<ExternalPackageReference>,
-) -> Result<(), SpdxError> {
+) {
     match atom {
         Atom::PackageName(value) => {
             if let Some(package) = &mut package_in_progress {
@@ -404,8 +404,6 @@ fn process_atom_for_packages(
         }
         _ => {}
     }
-
-    Ok(())
 }
 
 fn process_atom_for_files(
@@ -414,7 +412,7 @@ fn process_atom_for_files(
     files: &mut Vec<FileInformation>,
     package_in_progress: &Option<PackageInformation>,
     relationships: &mut HashSet<Relationship>,
-) -> Result<(), SpdxError> {
+) {
     match atom {
         Atom::PackageName(_) => {
             if let Some(file) = &mut file_in_progress {
@@ -492,14 +490,13 @@ fn process_atom_for_files(
         }
         _ => {}
     }
-    Ok(())
 }
 
 fn process_atom_for_snippets(
     atom: &Atom,
     snippets: &mut Vec<Snippet>,
     mut snippet_in_progress: &mut Option<Snippet>,
-) -> Result<(), SpdxError> {
+) {
     match atom {
         Atom::SnippetSPDXID(value) => {
             if let Some(snippet) = &snippet_in_progress {
@@ -571,7 +568,6 @@ fn process_atom_for_snippets(
         }
         _ => {}
     }
-    Ok(())
 }
 
 #[allow(clippy::unnecessary_wraps)]
@@ -579,7 +575,7 @@ fn process_atom_for_relationships(
     atom: &Atom,
     relationships: &mut HashSet<Relationship>,
     mut relationship_in_progress: &mut Option<Relationship>,
-) -> Result<(), SpdxError> {
+) {
     match atom {
         Atom::Relationship(value) => {
             if let Some(relationship) = relationship_in_progress {
@@ -594,8 +590,6 @@ fn process_atom_for_relationships(
         }
         _ => {}
     }
-
-    Ok(())
 }
 
 #[derive(Debug, Default)]

--- a/src/parsers/tag_value.rs
+++ b/src/parsers/tag_value.rs
@@ -377,6 +377,7 @@ fn package_verification_code(
             map(ws(not_line_ending), |v| (v, None)),
         )),
         |(value, exclude)| {
+            #[allow(clippy::option_if_let_else)]
             let excludes = if let Some(exclude) = exclude {
                 vec![exclude.to_string()]
             } else {


### PR DESCRIPTION
Change SPDXExpression to use String as the stored representation, and
only parse it when required. This allows the expressions to be non-spdx
compliant.
