### PR TITLE
bump strum 0.21 to 0.24

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,8 @@ log = "0.4"
 uuid = { version = "0.8", features = ["v4"] }
 chrono = { version = "0.4", features = ["serde"] }
 thiserror = "1"
-strum = "0.21"
-strum_macros = "0.21"
+strum = "0.24"
+strum_macros = "0.24"
 spdx-expression = "0.5.2"
 nom = "7"
 


### PR DESCRIPTION
I use `spdx-rs` with `clap`.

clap depends heck v0.4.0, 
strum 0.21 depends heck v0.3.3

```
warning[B004]: found 2 duplicate entries for crate 'heck'
   ┌─ /home/kazuk/sbom-ghr/Cargo.lock:56:1
   │  
56 │ ╭ heck 0.3.3 registry+https://github.com/rust-lang/crates.io-index
57 │ │ heck 0.4.0 registry+https://github.com/rust-lang/crates.io-index
```