### PR TITLE
Disable default features of chrono to avoid security vuln.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ exclude = [
 serde = { version = "1", features = [ "derive" ] }
 log = "0.4"
 uuid = { version = "1", features = ["v4"] }
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4", default-features = false, features = ["clock", "serde"] }
 thiserror = "1"
 strum = "0.24"
 strum_macros = "0.24"

--- a/src/models/annotation.rs
+++ b/src/models/annotation.rs
@@ -84,7 +84,7 @@ mod test {
         .unwrap();
         assert_eq!(
             spdx_file.annotations[0].annotation_date,
-            Utc.ymd(2010, 1, 29).and_hms(18, 30, 22)
+            Utc.with_ymd_and_hms(2010, 1, 29, 18, 30, 22).unwrap()
         );
     }
 

--- a/src/models/document_creation_information.rs
+++ b/src/models/document_creation_information.rs
@@ -236,7 +236,7 @@ mod test {
         .unwrap();
         assert_eq!(
             spdx.document_creation_information.creation_info.created,
-            Utc.ymd(2010, 1, 29).and_hms(18, 30, 22)
+            Utc.with_ymd_and_hms(2010, 1, 29, 18, 30, 22).unwrap()
         );
     }
     #[test]

--- a/src/parsers/mod.rs
+++ b/src/parsers/mod.rs
@@ -777,7 +777,7 @@ mod test_super {
             .contains(&"Person: Jane Doe ()".to_string()));
         assert_eq!(
             document_creation_information.creation_info.created,
-            Utc.ymd(2010, 1, 29).and_hms(18, 30, 22)
+            Utc.with_ymd_and_hms(2010, 1, 29, 18, 30, 22).unwrap()
         );
         assert_eq!(
             document_creation_information.creation_info.creator_comment,
@@ -1050,7 +1050,7 @@ THE SOFTWARE IS PROVIDED �AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMP
             annotations[2],
             Annotation::new(
                 "Person: Suzanne Reviewer".to_string(),
-                Utc.ymd(2011, 3, 13).and_hms(0, 0, 0),
+                Utc.with_ymd_and_hms(2011, 3, 13, 0, 0, 0).unwrap(),
                 AnnotationType::Review,
                 Some("SPDXRef-DOCUMENT".to_string()),
                 "Another example reviewer.".to_string()

--- a/src/parsers/tag_value.rs
+++ b/src/parsers/tag_value.rs
@@ -273,7 +273,7 @@ fn file_type(i: &str) -> IResult<&str, FileType, VerboseError<&str>> {
     }
 }
 
-fn document_ref<'a>(i: &'a str) -> IResult<&'a str, &str, VerboseError<&'a str>> {
+fn document_ref(i: &str) -> IResult<&str, &str, VerboseError<&str>> {
     preceded(tag("DocumentRef-"), ws(idstring))(i)
 }
 
@@ -395,7 +395,7 @@ fn range(i: &str) -> IResult<&str, (i32, i32), VerboseError<&str>> {
     )(i)
 }
 
-fn idstring<'a>(i: &'a str) -> IResult<&'a str, &str, VerboseError<&'a str>> {
+fn idstring(i: &str) -> IResult<&str, &str, VerboseError<&str>> {
     take_while(|c: char| c.is_alphanum() || c == '.' || c == '-' || c == '+')(i)
 }
 
@@ -427,7 +427,7 @@ fn tv_comment(i: &str) -> IResult<&str, Atom, VerboseError<&str>> {
     })(i)
 }
 
-fn tag_value<'a>(i: &'a str) -> IResult<&'a str, (&str, &str), VerboseError<&'a str>> {
+fn tag_value(i: &str) -> IResult<&str, (&str, &str), VerboseError<&str>> {
     separated_pair(
         ws(alphanumeric0),
         tag(":"),
@@ -435,7 +435,7 @@ fn tag_value<'a>(i: &'a str) -> IResult<&'a str, (&str, &str), VerboseError<&'a 
     )(i)
 }
 
-fn multiline_text<'a>(i: &'a str) -> IResult<&'a str, &str, VerboseError<&'a str>> {
+fn multiline_text(i: &str) -> IResult<&str, &str, VerboseError<&str>> {
     delimited(tag("<text>"), take_until("</text>"), tag("</text>"))(i)
 }
 


### PR DESCRIPTION
See https://github.com/chronotope/chrono/issues/602

If you do a `cargo deny check advisories` it would bring up an issue in time 0.1 (and there's apparently another in chrono itself for the same reason).

Also had to fix some clippy lints to make it past CI