### PR TITLE
Added support for SPDX 2.3 documents.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,3 +36,4 @@ nom = "7"
 
 [dev-dependencies]
 serde_json = "1"
+anyhow = "1"

--- a/src/models/checksum.rs
+++ b/src/models/checksum.rs
@@ -43,4 +43,18 @@ pub enum Algorithm {
     MD4,
     MD5,
     MD6,
+    #[serde(rename = "SHA3-256")]
+    SHA3256,
+    #[serde(rename = "SHA3-384")]
+    SHA3384,
+    #[serde(rename = "SHA3-512")]
+    SHA3512,
+    #[serde(rename = "BLAKE2b-256")]
+    BLAKE2B256,
+    #[serde(rename = "BLAKE2b-384")]
+    BLAKE2B384,
+    #[serde(rename = "BLAKE2b-512")]
+    BLAKE2B512,
+    BLAKE3,
+    ADLER32,
 }

--- a/src/models/file_information.rs
+++ b/src/models/file_information.rs
@@ -29,11 +29,19 @@ pub struct FileInformation {
     pub file_checksum: Vec<Checksum>,
 
     /// <https://spdx.github.io/spdx-spec/4-file-information/#45-concluded-license>
-    #[serde(rename = "licenseConcluded")]
-    pub concluded_license: SpdxExpression,
+    #[serde(
+        rename = "licenseConcluded",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
+    pub concluded_license: Option<SpdxExpression>,
 
     /// <https://spdx.github.io/spdx-spec/4-file-information/#46-license-information-in-file>
-    #[serde(rename = "licenseInfoInFiles")]
+    #[serde(
+        rename = "licenseInfoInFiles",
+        skip_serializing_if = "Vec::is_empty",
+        default
+    )]
     pub license_information_in_file: Vec<SimpleExpression>,
 
     /// <https://spdx.github.io/spdx-spec/4-file-information/#47-comments-on-license>
@@ -45,7 +53,12 @@ pub struct FileInformation {
     pub comments_on_license: Option<String>,
 
     /// <https://spdx.github.io/spdx-spec/4-file-information/#48-copyright-text>
-    pub copyright_text: String,
+    #[serde(
+        rename = "copyrightText",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
+    pub copyright_text: Option<String>,
 
     /// <https://spdx.github.io/spdx-spec/4-file-information/#412-file-comment>
     #[serde(rename = "comment", skip_serializing_if = "Option::is_none", default)]
@@ -80,10 +93,10 @@ impl Default for FileInformation {
             file_spdx_identifier: "NOASSERTION".to_string(),
             file_type: Vec::new(),
             file_checksum: Vec::new(),
-            concluded_license: SpdxExpression::parse("NOASSERTION").expect("will always succeed"),
+            concluded_license: None,
             license_information_in_file: Vec::new(),
             comments_on_license: None,
-            copyright_text: "NOASSERTION".to_string(),
+            copyright_text: None,
             file_comment: None,
             file_notice: None,
             file_contributor: Vec::new(),
@@ -98,7 +111,7 @@ impl FileInformation {
         *id += 1;
         Self {
             file_name: name.to_string(),
-            file_spdx_identifier: format!("SPDXRef-{}", id),
+            file_spdx_identifier: format!("SPDXRef-{id}"),
             ..Self::default()
         }
     }
@@ -241,7 +254,7 @@ mod test {
         .unwrap();
         assert_eq!(
             spdx.file_information[0].concluded_license,
-            SpdxExpression::parse("Apache-2.0").unwrap()
+            Some(SpdxExpression::parse("Apache-2.0").unwrap())
         );
     }
     #[test]
@@ -273,7 +286,11 @@ mod test {
         )
         .unwrap();
         assert_eq!(
-            spdx.file_information[0].copyright_text,
+            spdx.file_information[0]
+                .copyright_text
+                .as_ref()
+                .unwrap()
+                .clone(),
             "Copyright 2010, 2011 Source Auditor Inc.".to_string()
         );
     }

--- a/src/models/package_information.rs
+++ b/src/models/package_information.rs
@@ -76,8 +76,12 @@ pub struct PackageInformation {
     pub source_information: Option<String>,
 
     /// <https://spdx.github.io/spdx-spec/3-package-information/#313-concluded-license>
-    #[serde(rename = "licenseConcluded")]
-    pub concluded_license: SpdxExpression,
+    #[serde(
+        rename = "licenseConcluded",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
+    pub concluded_license: Option<SpdxExpression>,
 
     /// <https://spdx.github.io/spdx-spec/3-package-information/#314-all-licenses-information-from-files>
     #[serde(
@@ -88,8 +92,12 @@ pub struct PackageInformation {
     pub all_licenses_information_from_files: Vec<String>,
 
     /// <https://spdx.github.io/spdx-spec/3-package-information/#315-declared-license>
-    #[serde(rename = "licenseDeclared")]
-    pub declared_license: SpdxExpression,
+    #[serde(
+        rename = "licenseDeclared",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
+    pub declared_license: Option<SpdxExpression>,
 
     /// <https://spdx.github.io/spdx-spec/3-package-information/#316-comments-on-license>
     #[serde(
@@ -100,7 +108,12 @@ pub struct PackageInformation {
     pub comments_on_license: Option<String>,
 
     /// <https://spdx.github.io/spdx-spec/3-package-information/#317-copyright-text>
-    pub copyright_text: String,
+    #[serde(
+        rename = "copyrightText",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
+    pub copyright_text: Option<String>,
 
     /// <https://spdx.github.io/spdx-spec/3-package-information/#318-package-summary-description>
     #[serde(rename = "summary", skip_serializing_if = "Option::is_none", default)]
@@ -142,6 +155,30 @@ pub struct PackageInformation {
 
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub annotations: Vec<Annotation>,
+
+    #[serde(rename = "builtDate", skip_serializing_if = "Option::is_none", default)]
+    pub built_date: Option<String>,
+
+    #[serde(
+        rename = "releaseDate",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
+    pub release_date: Option<String>,
+
+    #[serde(
+        rename = "validUntilDate",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
+    pub valid_until_date: Option<String>,
+
+    #[serde(
+        rename = "primaryPackagePurpose",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
+    pub primary_package_purpose: Option<PrimaryPackagePurpose>,
 }
 
 impl Default for PackageInformation {
@@ -159,11 +196,11 @@ impl Default for PackageInformation {
             package_checksum: Vec::new(),
             package_home_page: None,
             source_information: None,
-            concluded_license: SpdxExpression::parse("NONE").expect("will always succeed"),
+            concluded_license: None,
             all_licenses_information_from_files: Vec::new(),
-            declared_license: SpdxExpression::parse("NONE").expect("will always succeed"),
+            declared_license: None,
             comments_on_license: None,
-            copyright_text: "NOASSERTION".to_string(),
+            copyright_text: None,
             package_summary_description: None,
             package_detailed_description: None,
             package_comment: None,
@@ -171,6 +208,10 @@ impl Default for PackageInformation {
             package_attribution_text: Vec::new(),
             files: Vec::new(),
             annotations: Vec::new(),
+            built_date: None,
+            release_date: None,
+            valid_until_date: None,
+            primary_package_purpose: None,
         }
     }
 }
@@ -181,7 +222,7 @@ impl PackageInformation {
         *id += 1;
         Self {
             package_name: name.to_string(),
-            package_spdx_identifier: format!("SPDXRef-{}", id),
+            package_spdx_identifier: format!("SPDXRef-{id}"),
             ..Self::default()
         }
     }
@@ -260,6 +301,23 @@ pub enum ExternalPackageReferenceCategory {
     Security,
     PackageManager,
     PersistentID,
+    Other,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Copy)]
+#[serde(rename_all = "SCREAMING-KEBAB-CASE")]
+pub enum PrimaryPackagePurpose {
+    Application,
+    Framework,
+    Library,
+    Container,
+    OperatingSystem,
+    Device,
+    Firmware,
+    Source,
+    Archive,
+    File,
+    Install,
     Other,
 }
 
@@ -432,7 +490,11 @@ mod test {
         )
         .unwrap();
         assert_eq!(
-            spdx.package_information[0].concluded_license,
+            spdx.package_information[0]
+                .concluded_license
+                .as_ref()
+                .unwrap()
+                .clone(),
             SpdxExpression::parse("(LGPL-2.0-only OR LicenseRef-3)").unwrap()
         );
     }
@@ -459,7 +521,11 @@ mod test {
         )
         .unwrap();
         assert_eq!(
-            spdx.package_information[0].declared_license,
+            spdx.package_information[0]
+                .declared_license
+                .as_ref()
+                .unwrap()
+                .clone(),
             SpdxExpression::parse("(LGPL-2.0-only AND LicenseRef-3)").unwrap()
         );
     }
@@ -481,7 +547,11 @@ mod test {
         )
         .unwrap();
         assert_eq!(
-            spdx.package_information[0].copyright_text,
+            spdx.package_information[0]
+                .copyright_text
+                .as_ref()
+                .unwrap()
+                .clone(),
             "Copyright 2008-2010 John Smith".to_string()
         );
     }

--- a/src/models/relationship.rs
+++ b/src/models/relationship.rs
@@ -87,6 +87,8 @@ pub enum RelationshipType {
     Amends,
     PrerequisiteFor,
     HasPrerequisite,
+    RequirementDescriptionFor,
+    SpecificationFor,
     Other,
 }
 

--- a/src/models/snippet.rs
+++ b/src/models/snippet.rs
@@ -20,8 +20,12 @@ pub struct Snippet {
     pub ranges: Vec<Range>,
 
     /// <https://spdx.github.io/spdx-spec/5-snippet-information/#55-snippet-concluded-license>
-    #[serde(rename = "licenseConcluded")]
-    pub snippet_concluded_license: SpdxExpression,
+    #[serde(
+        rename = "licenseConcluded",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
+    pub snippet_concluded_license: Option<SpdxExpression>,
 
     /// <https://spdx.github.io/spdx-spec/5-snippet-information/#56-license-information-in-snippet>
     #[serde(
@@ -40,8 +44,12 @@ pub struct Snippet {
     pub snippet_comments_on_license: Option<String>,
 
     /// <https://spdx.github.io/spdx-spec/5-snippet-information/#58-snippet-copyright-text>
-    #[serde(rename = "copyrightText")]
-    pub snippet_copyright_text: String,
+    #[serde(
+        rename = "copyrightText",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
+    pub snippet_copyright_text: Option<String>,
 
     /// <https://spdx.github.io/spdx-spec/5-snippet-information/#59-snippet-comment>
     #[serde(rename = "comment", skip_serializing_if = "Option::is_none", default)]
@@ -175,7 +183,11 @@ mod test {
         )
         .unwrap();
         assert_eq!(
-            spdx.snippet_information[0].snippet_concluded_license,
+            spdx.snippet_information[0]
+                .snippet_concluded_license
+                .as_ref()
+                .unwrap()
+                .clone(),
             SpdxExpression::parse("GPL-2.0-only").unwrap()
         );
     }
@@ -208,7 +220,11 @@ mod test {
         )
         .unwrap();
         assert_eq!(
-            spdx.snippet_information[0].snippet_copyright_text,
+            spdx.snippet_information[0]
+                .snippet_copyright_text
+                .as_ref()
+                .unwrap()
+                .clone(),
             "Copyright 2008-2010 John Smith".to_string()
         );
     }

--- a/src/models/spdx_document.rs
+++ b/src/models/spdx_document.rs
@@ -155,9 +155,11 @@ impl SPDX {
         let mut license_ids = HashSet::new();
 
         for file in &self.file_information {
-            for license in &file.concluded_license.identifiers() {
-                if license != "NOASSERTION" && license != "NONE" {
-                    license_ids.insert(license.clone());
+            if let Some(concluded_license) = &file.concluded_license {
+                for license in concluded_license.identifiers() {
+                    if license != "NOASSERTION" && license != "NONE" {
+                        license_ids.insert(license.clone());
+                    }
                 }
             }
         }
@@ -228,7 +230,7 @@ mod test {
 
         assert_eq!(
             file.0.concluded_license,
-            SpdxExpression::parse("LicenseRef-1").unwrap()
+            Some(SpdxExpression::parse("LicenseRef-1").unwrap())
         );
     }
 

--- a/src/parsers/mod.rs
+++ b/src/parsers/mod.rs
@@ -350,7 +350,7 @@ fn process_atom_for_packages(
         }
         Atom::PackageLicenseConcluded(value) => {
             if let Some(package) = &mut package_in_progress {
-                package.concluded_license = SpdxExpression::parse(value).unwrap();
+                package.concluded_license = Some(SpdxExpression::parse(value).unwrap());
             }
         }
         Atom::PackageLicenseInfoFromFiles(value) => {
@@ -362,7 +362,7 @@ fn process_atom_for_packages(
         }
         Atom::PackageLicenseDeclared(value) => {
             if let Some(package) = &mut package_in_progress {
-                package.declared_license = SpdxExpression::parse(value).unwrap();
+                package.declared_license = Some(SpdxExpression::parse(value).unwrap());
             }
         }
         Atom::PackageLicenseComments(value) => {
@@ -372,7 +372,7 @@ fn process_atom_for_packages(
         }
         Atom::PackageCopyrightText(value) => {
             if let Some(package) = &mut package_in_progress {
-                package.copyright_text = value.clone();
+                package.copyright_text = Some(value.clone());
             }
         }
         Atom::PackageSummary(value) => {
@@ -461,7 +461,7 @@ fn process_atom_for_files(
         }
         Atom::LicenseConcluded(value) => {
             if let Some(file) = &mut file_in_progress {
-                file.concluded_license = SpdxExpression::parse(value).unwrap();
+                file.concluded_license = Some(SpdxExpression::parse(value).unwrap());
             }
         }
         Atom::LicenseInfoInFile(value) => {
@@ -477,7 +477,7 @@ fn process_atom_for_files(
         }
         Atom::FileCopyrightText(value) => {
             if let Some(file) = &mut file_in_progress {
-                file.copyright_text = value.clone();
+                file.copyright_text = Some(value.clone());
             }
         }
         Atom::FileNotice(value) => {
@@ -533,7 +533,7 @@ fn process_atom_for_snippets(
         }
         Atom::SnippetLicenseConcluded(value) => {
             if let Some(snippet) = &mut snippet_in_progress {
-                snippet.snippet_concluded_license = SpdxExpression::parse(value).unwrap();
+                snippet.snippet_concluded_license = Some(SpdxExpression::parse(value).unwrap());
             }
         }
         Atom::LicenseInfoInSnippet(value) => {
@@ -550,7 +550,7 @@ fn process_atom_for_snippets(
         }
         Atom::SnippetCopyrightText(value) => {
             if let Some(snippet) = &mut snippet_in_progress {
-                snippet.snippet_copyright_text = value.to_string();
+                snippet.snippet_copyright_text = Some(value.to_string());
             }
         }
         Atom::SnippetComment(value) => {
@@ -850,7 +850,7 @@ compatible system run time libraries."
             Some("uses glibc-2_11-branch from git://sourceware.org/git/glibc.git.".to_string())
         );
         assert_eq!(
-            glibc.concluded_license.identifiers(),
+            glibc.concluded_license.as_ref().unwrap().identifiers(),
             HashSet::from_iter(["LGPL-2.0-only".to_string(), "LicenseRef-3".to_string()])
         );
         assert_eq!(
@@ -858,11 +858,14 @@ compatible system run time libraries."
             vec!["GPL-2.0-only", "LicenseRef-2", "LicenseRef-1"]
         );
         assert_eq!(
-            glibc.declared_license.identifiers(),
+            glibc.declared_license.as_ref().unwrap().identifiers(),
             HashSet::from_iter(["LGPL-2.0-only".to_string(), "LicenseRef-3".to_string()])
         );
         assert_eq!(glibc.comments_on_license, Some("The license for this project changed with the release of version x.y.  The version of the project included here post-dates the license change.".to_string()));
-        assert_eq!(glibc.copyright_text, "Copyright 2008-2010 John Smith");
+        assert_eq!(
+            glibc.copyright_text.as_ref().unwrap().clone(),
+            "Copyright 2008-2010 John Smith"
+        );
         assert_eq!(
             glibc.package_summary_description,
             Some("GNU C library.".to_string())
@@ -925,7 +928,7 @@ This information was found in the COPYING.txt file in the xyz directory.".to_str
             ]
         );
         assert_eq!(
-            fooc.concluded_license.identifiers(),
+            fooc.concluded_license.as_ref().unwrap().identifiers(),
             HashSet::from_iter(["LGPL-2.0-only".to_string(), "LicenseRef-2".to_string(),])
         );
         assert_eq!(
@@ -937,7 +940,7 @@ This information was found in the COPYING.txt file in the xyz directory.".to_str
         );
         assert_eq!(fooc.comments_on_license, Some("The concluded license was taken from the package level that the file was included in.".to_string()));
         assert_eq!(
-            fooc.copyright_text,
+            fooc.copyright_text.as_ref().unwrap().clone(),
             "Copyright 2008-2010 John Smith".to_string()
         );
         assert_eq!(
@@ -997,13 +1000,13 @@ THE SOFTWARE IS PROVIDED �AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMP
             .iter()
             .any(|snip| snip.end_pointer == Pointer::new_line(None, 23)));
         assert_eq!(
-            snippet.snippet_concluded_license,
+            snippet.snippet_concluded_license.unwrap(),
             SpdxExpression::parse("GPL-2.0-only").unwrap()
         );
         assert_eq!(snippet.license_information_in_snippet, vec!["GPL-2.0-only"]);
         assert_eq!(snippet.snippet_comments_on_license, Some("The concluded license was taken from package xyz, from which the snippet was copied into the current file. The concluded license information was found in the COPYING.txt file in package xyz.".to_string()));
         assert_eq!(
-            snippet.snippet_copyright_text,
+            snippet.snippet_copyright_text.as_ref().unwrap().clone(),
             "Copyright 2008-2010 John Smith"
         );
         assert_eq!(snippet.snippet_comment, Some("This snippet was identified as significant and highlighted in this Apache-2.0 file, when a commercial scanner identified it as being derived from file foo.c in package xyz which is licensed under GPL-2.0.".to_string()));

--- a/src/parsers/tag_value.rs
+++ b/src/parsers/tag_value.rs
@@ -60,6 +60,10 @@ pub(super) enum Atom {
     ExternalRef(ExternalPackageReference),
     ExternalRefComment(String),
     PackageAttributionText(String),
+    PrimaryPackagePurpose(String),
+    BuiltDate(String),
+    ReleaseDate(String),
+    ValidUntilDate(String),
 
     // File Information
     FileName(String),
@@ -168,6 +172,10 @@ fn tag_value_to_atom(i: &str) -> IResult<&str, Atom, VerboseError<&str>> {
         )),
         "ExternalRefComment" => Ok((i, Atom::ExternalRefComment(key_value.1.to_string()))),
         "PackageAttributionText" => Ok((i, Atom::PackageAttributionText(key_value.1.to_string()))),
+        "PrimaryPackagePurpose" => Ok((i, Atom::PrimaryPackagePurpose(key_value.1.to_string()))),
+        "BuiltDate" => Ok((i, Atom::BuiltDate(key_value.1.to_string()))),
+        "ReleaseDate" => Ok((i, Atom::ReleaseDate(key_value.1.to_string()))),
+        "ValidUntilDate" => Ok((i, Atom::ValidUntilDate(key_value.1.to_string()))),
 
         // File Information
         "FileName" => Ok((i, Atom::FileName(key_value.1.to_string()))),
@@ -329,6 +337,8 @@ fn relationship(i: &str) -> IResult<&str, Relationship, VerboseError<&str>> {
                 "AMENDS" => RelationshipType::Amends,
                 "PREREQUISITE_FOR" => RelationshipType::PrerequisiteFor,
                 "HAS_PREREQUISITE" => RelationshipType::HasPrerequisite,
+                "SPECIFICATION_FOR" => RelationshipType::SpecificationFor,
+                "REQUIREMENT_DESCRIPTION_FOR" => RelationshipType::RequirementDescriptionFor,
                 "OTHER" => RelationshipType::Other,
                 // TODO: Proper error.
                 _ => {
@@ -413,6 +423,14 @@ fn checksum(i: &str) -> IResult<&str, Checksum, VerboseError<&str>> {
                 "MD4" => Algorithm::MD4,
                 "MD5" => Algorithm::MD5,
                 "MD6" => Algorithm::MD6,
+                "SHA3-256" => Algorithm::SHA3256,
+                "SHA3-384" => Algorithm::SHA3384,
+                "SHA3-512" => Algorithm::SHA3512,
+                "BLAKE2b-256" => Algorithm::BLAKE2B256,
+                "BLAKE2b-384" => Algorithm::BLAKE2B384,
+                "BLAKE2b-512" => Algorithm::BLAKE2B512,
+                "BLAKE3" => Algorithm::BLAKE3,
+                "ADLER32" => Algorithm::ADLER32,
                 // TODO: Use proper error.
                 _ => todo!(),
             };

--- a/tests/data/SPDXJSONExample-v2.3.spdx.json
+++ b/tests/data/SPDXJSONExample-v2.3.spdx.json
@@ -1,0 +1,289 @@
+{
+    "SPDXID" : "SPDXRef-DOCUMENT",
+    "spdxVersion" : "SPDX-2.3",
+    "creationInfo" : {
+      "comment" : "This package has been shipped in source and binary form.\nThe binaries were created with gcc 4.5.1 and expect to link to\ncompatible system run time libraries.",
+      "created" : "2010-01-29T18:30:22Z",
+      "creators" : [ "Tool: LicenseFind-1.0", "Organization: ExampleCodeInspect ()", "Person: Jane Doe ()" ],
+      "licenseListVersion" : "3.17"
+    },
+    "name" : "SPDX-Tools-v2.0",
+    "dataLicense" : "CC0-1.0",
+    "comment" : "This document was created using SPDX 2.0 using licenses from the web site.",
+    "externalDocumentRefs" : [ {
+      "externalDocumentId" : "DocumentRef-spdx-tool-1.2",
+      "checksum" : {
+        "algorithm" : "SHA1",
+        "checksumValue" : "d6a770ba38583ed4bb4525bd96e50461655d2759"
+      },
+      "spdxDocument" : "http://spdx.org/spdxdocs/spdx-tools-v1.2-3F2504E0-4F89-41D3-9A0C-0305E82C3301"
+    } ],
+    "hasExtractedLicensingInfos" : [ {
+      "licenseId" : "LicenseRef-1",
+      "extractedText" : "/*\n * (c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP\n * All rights reserved.\n *\n * Redistribution and use in source and binary forms, with or without\n * modification, are permitted provided that the following conditions\n * are met:\n * 1. Redistributions of source code must retain the above copyright\n *    notice, this list of conditions and the following disclaimer.\n * 2. Redistributions in binary form must reproduce the above copyright\n *    notice, this list of conditions and the following disclaimer in the\n *    documentation and/or other materials provided with the distribution.\n * 3. The name of the author may not be used to endorse or promote products\n *    derived from this software without specific prior written permission.\n *\n * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR\n * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\n * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.\n * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,\n * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT\n * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\n * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY\n * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT\n * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF\n * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n*/"
+    }, {
+      "licenseId" : "LicenseRef-2",
+      "extractedText" : "This package includes the GRDDL parser developed by Hewlett Packard under the following license:\n© Copyright 2007 Hewlett-Packard Development Company, LP\n\nRedistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: \n\nRedistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. \nRedistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution. \nThe name of the author may not be used to endorse or promote products derived from this software without specific prior written permission. \nTHIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+    }, {
+      "licenseId" : "LicenseRef-4",
+      "extractedText" : "/*\n * (c) Copyright 2009 University of Bristol\n * All rights reserved.\n *\n * Redistribution and use in source and binary forms, with or without\n * modification, are permitted provided that the following conditions\n * are met:\n * 1. Redistributions of source code must retain the above copyright\n *    notice, this list of conditions and the following disclaimer.\n * 2. Redistributions in binary form must reproduce the above copyright\n *    notice, this list of conditions and the following disclaimer in the\n *    documentation and/or other materials provided with the distribution.\n * 3. The name of the author may not be used to endorse or promote products\n *    derived from this software without specific prior written permission.\n *\n * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR\n * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\n * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.\n * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,\n * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT\n * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,\n * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY\n * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT\n * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF\n * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n*/"
+    }, {
+      "licenseId" : "LicenseRef-Beerware-4.2",
+      "comment" : "The beerware license has a couple of other standard variants.",
+      "extractedText" : "\"THE BEER-WARE LICENSE\" (Revision 42):\nphk@FreeBSD.ORG wrote this file. As long as you retain this notice you\ncan do whatever you want with this stuff. If we meet some day, and you think this stuff is worth it, you can buy me a beer in return Poul-Henning Kamp",
+      "name" : "Beer-Ware License (Version 42)",
+      "seeAlsos" : [ "http://people.freebsd.org/~phk/" ]
+    }, {
+      "licenseId" : "LicenseRef-3",
+      "comment" : "This is tye CyperNeko License",
+      "extractedText" : "The CyberNeko Software License, Version 1.0\n\n \n(C) Copyright 2002-2005, Andy Clark.  All rights reserved.\n \nRedistribution and use in source and binary forms, with or without\nmodification, are permitted provided that the following conditions\nare met:\n\n1. Redistributions of source code must retain the above copyright\n   notice, this list of conditions and the following disclaimer. \n\n2. Redistributions in binary form must reproduce the above copyright\n   notice, this list of conditions and the following disclaimer in\n   the documentation and/or other materials provided with the\n   distribution.\n\n3. The end-user documentation included with the redistribution,\n   if any, must include the following acknowledgment:  \n     \"This product includes software developed by Andy Clark.\"\n   Alternately, this acknowledgment may appear in the software itself,\n   if and wherever such third-party acknowledgments normally appear.\n\n4. The names \"CyberNeko\" and \"NekoHTML\" must not be used to endorse\n   or promote products derived from this software without prior \n   written permission. For written permission, please contact \n   andyc@cyberneko.net.\n\n5. Products derived from this software may not be called \"CyberNeko\",\n   nor may \"CyberNeko\" appear in their name, without prior written\n   permission of the author.\n\nTHIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED\nWARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES\nOF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE\nDISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR OTHER CONTRIBUTORS\nBE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, \nOR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT \nOF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR \nBUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, \nWHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE \nOR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, \nEVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.",
+      "name" : "CyberNeko License",
+      "seeAlsos" : [ "http://people.apache.org/~andyc/neko/LICENSE", "http://justasample.url.com" ]
+    } ],
+    "annotations" : [ {
+      "annotationDate" : "2010-01-29T18:30:22Z",
+      "annotationType" : "OTHER",
+      "annotator" : "Person: Jane Doe ()",
+      "comment" : "Document level annotation"
+    }, {
+      "annotationDate" : "2010-02-10T00:00:00Z",
+      "annotationType" : "REVIEW",
+      "annotator" : "Person: Joe Reviewer",
+      "comment" : "This is just an example.  Some of the non-standard licenses look like they are actually BSD 3 clause licenses"
+    }, {
+      "annotationDate" : "2011-03-13T00:00:00Z",
+      "annotationType" : "REVIEW",
+      "annotator" : "Person: Suzanne Reviewer",
+      "comment" : "Another example reviewer."
+    } ],
+    "documentDescribes" : [ "SPDXRef-File", "SPDXRef-Package" ],
+    "documentNamespace" : "http://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301",
+    "packages" : [ {
+      "SPDXID" : "SPDXRef-Package",
+      "annotations" : [ {
+        "annotationDate" : "2011-01-29T18:30:22Z",
+        "annotationType" : "OTHER",
+        "annotator" : "Person: Package Commenter",
+        "comment" : "Package level annotation"
+      } ],
+      "attributionTexts" : [ "The GNU C Library is free software.  See the file COPYING.LIB for copying conditions, and LICENSES for notices about a few contributions that require these additional notices to be distributed.  License copyright years may be listed using range notation, e.g., 1996-2015, indicating that every year in the range, inclusive, is a copyrightable year that would otherwise be listed individually." ],
+      "builtDate" : "2011-01-29T18:30:22Z",
+      "checksums" : [ {
+        "algorithm" : "MD5",
+        "checksumValue" : "624c1abb3664f4b35547e7c73864ad24"
+      }, {
+        "algorithm" : "SHA1",
+        "checksumValue" : "85ed0817af83a24ad8da68c2b5094de69833983c"
+      }, {
+        "algorithm" : "SHA256",
+        "checksumValue" : "11b6d3ee554eedf79299905a98f9b9a04e498210b59f15094c916c91d150efcd"
+      }, {
+        "algorithm" : "BLAKE2b-384",
+        "checksumValue" : "aaabd89c926ab525c242e6621f2f5fa73aa4afe3d9e24aed727faaadd6af38b620bdb623dd2b4788b1c8086984af8706"
+      } ],
+      "copyrightText" : "Copyright 2008-2010 John Smith",
+      "description" : "The GNU C Library defines functions that are specified by the ISO C standard, as well as additional features specific to POSIX and other derivatives of the Unix operating system, and extensions specific to GNU systems.",
+      "downloadLocation" : "http://ftp.gnu.org/gnu/glibc/glibc-ports-2.15.tar.gz",
+      "externalRefs" : [ {
+        "referenceCategory" : "SECURITY",
+        "referenceLocator" : "cpe:2.3:a:pivotal_software:spring_framework:4.1.0:*:*:*:*:*:*:*",
+        "referenceType" : "cpe23Type"
+      }, {
+        "comment" : "This is the external ref for Acme",
+        "referenceCategory" : "OTHER",
+        "referenceLocator" : "acmecorp/acmenator/4.1.3-alpha",
+        "referenceType" : "http://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301#LocationRef-acmeforge"
+      } ],
+      "filesAnalyzed" : true,
+      "homepage" : "http://ftp.gnu.org/gnu/glibc",
+      "licenseComments" : "The license for this project changed with the release of version x.y.  The version of the project included here post-dates the license change.",
+      "licenseConcluded" : "(LGPL-2.0-only OR LicenseRef-3)",
+      "licenseDeclared" : "(LGPL-2.0-only AND LicenseRef-3)",
+      "licenseInfoFromFiles" : [ "GPL-2.0-only", "LicenseRef-2", "LicenseRef-1" ],
+      "name" : "glibc",
+      "originator" : "Organization: ExampleCodeInspect (contact@example.com)",
+      "packageFileName" : "glibc-2.11.1.tar.gz",
+      "packageVerificationCode" : {
+        "packageVerificationCodeExcludedFiles" : [ "./package.spdx" ],
+        "packageVerificationCodeValue" : "d6a770ba38583ed4bb4525bd96e50461655d2758"
+      },
+      "primaryPackagePurpose" : "SOURCE",
+      "hasFiles" : [ "SPDXRef-Specification", "SPDXRef-Specification", "SPDXRef-CommonsLangSrc", "SPDXRef-Specification", "SPDXRef-CommonsLangSrc", "SPDXRef-JenaLib", "SPDXRef-Specification", "SPDXRef-CommonsLangSrc", "SPDXRef-JenaLib", "SPDXRef-DoapSource", "SPDXRef-Specification", "SPDXRef-CommonsLangSrc", "SPDXRef-JenaLib", "SPDXRef-DoapSource" ],
+      "releaseDate" : "2012-01-29T18:30:22Z",
+      "sourceInfo" : "uses glibc-2_11-branch from git://sourceware.org/git/glibc.git.",
+      "summary" : "GNU C library.",
+      "supplier" : "Person: Jane Doe (jane.doe@example.com)",
+      "validUntilDate" : "2014-01-29T18:30:22Z",
+      "versionInfo" : "2.11.1"
+    }, {
+      "SPDXID" : "SPDXRef-fromDoap-1",
+      "copyrightText" : "NOASSERTION",
+      "downloadLocation" : "NOASSERTION",
+      "filesAnalyzed" : false,
+      "homepage" : "http://commons.apache.org/proper/commons-lang/",
+      "licenseConcluded" : "NOASSERTION",
+      "licenseDeclared" : "NOASSERTION",
+      "name" : "Apache Commons Lang"
+    }, {
+      "SPDXID" : "SPDXRef-fromDoap-0",
+      "downloadLocation" : "https://search.maven.org/remotecontent?filepath=org/apache/jena/apache-jena/3.12.0/apache-jena-3.12.0.tar.gz",
+      "externalRefs" : [ {
+        "referenceCategory" : "PACKAGE-MANAGER",
+        "referenceLocator" : "pkg:maven/org.apache.jena/apache-jena@3.12.0",
+        "referenceType" : "purl"
+      } ],
+      "filesAnalyzed" : false,
+      "homepage" : "http://www.openjena.org/",
+      "name" : "Jena",
+      "versionInfo" : "3.12.0"
+    }, {
+      "SPDXID" : "SPDXRef-Saxon",
+      "checksums" : [ {
+        "algorithm" : "SHA1",
+        "checksumValue" : "85ed0817af83a24ad8da68c2b5094de69833983c"
+      } ],
+      "copyrightText" : "Copyright Saxonica Ltd",
+      "description" : "The Saxon package is a collection of tools for processing XML documents.",
+      "downloadLocation" : "https://sourceforge.net/projects/saxon/files/Saxon-B/8.8.0.7/saxonb8-8-0-7j.zip/download",
+      "filesAnalyzed" : false,
+      "homepage" : "http://saxon.sourceforge.net/",
+      "licenseComments" : "Other versions available for a commercial license",
+      "licenseConcluded" : "MPL-1.0",
+      "licenseDeclared" : "MPL-1.0",
+      "name" : "Saxon",
+      "packageFileName" : "saxonB-8.8.zip",
+      "versionInfo" : "8.8"
+    } ],
+    "files" : [ {
+      "SPDXID" : "SPDXRef-DoapSource",
+      "checksums" : [ {
+        "algorithm" : "SHA1",
+        "checksumValue" : "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12"
+      } ],
+      "copyrightText" : "Copyright 2010, 2011 Source Auditor Inc.",
+      "fileContributors" : [ "Protecode Inc.", "SPDX Technical Team Members", "Open Logic Inc.", "Source Auditor Inc.", "Black Duck Software In.c" ],
+      "fileName" : "./src/org/spdx/parser/DOAPProject.java",
+      "fileTypes" : [ "SOURCE" ],
+      "licenseConcluded" : "Apache-2.0",
+      "licenseInfoInFiles" : [ "Apache-2.0" ]
+    }, {
+      "SPDXID" : "SPDXRef-CommonsLangSrc",
+      "checksums" : [ {
+        "algorithm" : "SHA1",
+        "checksumValue" : "c2b4e1c67a2d28fced849ee1bb76e7391b93f125"
+      } ],
+      "comment" : "This file is used by Jena",
+      "copyrightText" : "Copyright 2001-2011 The Apache Software Foundation",
+      "fileContributors" : [ "Apache Software Foundation" ],
+      "fileName" : "./lib-source/commons-lang3-3.1-sources.jar",
+      "fileTypes" : [ "ARCHIVE" ],
+      "licenseConcluded" : "Apache-2.0",
+      "licenseInfoInFiles" : [ "Apache-2.0" ],
+      "noticeText" : "Apache Commons Lang\nCopyright 2001-2011 The Apache Software Foundation\n\nThis product includes software developed by\nThe Apache Software Foundation (http://www.apache.org/).\n\nThis product includes software from the Spring Framework,\nunder the Apache License 2.0 (see: StringUtils.containsWhitespace())"
+    }, {
+      "SPDXID" : "SPDXRef-JenaLib",
+      "checksums" : [ {
+        "algorithm" : "SHA1",
+        "checksumValue" : "3ab4e1c67a2d28fced849ee1bb76e7391b93f125"
+      } ],
+      "comment" : "This file belongs to Jena",
+      "copyrightText" : "(c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP",
+      "fileContributors" : [ "Apache Software Foundation", "Hewlett Packard Inc." ],
+      "fileName" : "./lib-source/jena-2.6.3-sources.jar",
+      "fileTypes" : [ "ARCHIVE" ],
+      "licenseComments" : "This license is used by Jena",
+      "licenseConcluded" : "LicenseRef-1",
+      "licenseInfoInFiles" : [ "LicenseRef-1" ]
+    }, {
+      "SPDXID" : "SPDXRef-Specification",
+      "checksums" : [ {
+        "algorithm" : "SHA1",
+        "checksumValue" : "fff4e1c67a2d28fced849ee1bb76e7391b93f125"
+      } ],
+      "comment" : "Specification Documentation",
+      "fileName" : "./docs/myspec.pdf",
+      "fileTypes" : [ "DOCUMENTATION" ]
+    }, {
+      "SPDXID" : "SPDXRef-File",
+      "annotations" : [ {
+        "annotationDate" : "2011-01-29T18:30:22Z",
+        "annotationType" : "OTHER",
+        "annotator" : "Person: File Commenter",
+        "comment" : "File level annotation"
+      } ],
+      "checksums" : [ {
+        "algorithm" : "SHA1",
+        "checksumValue" : "d6a770ba38583ed4bb4525bd96e50461655d2758"
+      }, {
+        "algorithm" : "MD5",
+        "checksumValue" : "624c1abb3664f4b35547e7c73864ad24"
+      } ],
+      "comment" : "The concluded license was taken from the package level that the file was included in.\nThis information was found in the COPYING.txt file in the xyz directory.",
+      "copyrightText" : "Copyright 2008-2010 John Smith",
+      "fileContributors" : [ "The Regents of the University of California", "Modified by Paul Mundt lethal@linux-sh.org", "IBM Corporation" ],
+      "fileName" : "./package/foo.c",
+      "fileTypes" : [ "SOURCE" ],
+      "licenseComments" : "The concluded license was taken from the package level that the file was included in.",
+      "licenseConcluded" : "(LGPL-2.0-only OR LicenseRef-2)",
+      "licenseInfoInFiles" : [ "GPL-2.0-only", "LicenseRef-2" ],
+      "noticeText" : "Copyright (c) 2001 Aaron Lehmann aaroni@vitelus.com\n\nPermission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the \"Software\"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: \nThe above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE."
+    } ],
+    "snippets" : [ {
+      "SPDXID" : "SPDXRef-Snippet",
+      "comment" : "This snippet was identified as significant and highlighted in this Apache-2.0 file, when a commercial scanner identified it as being derived from file foo.c in package xyz which is licensed under GPL-2.0.",
+      "copyrightText" : "Copyright 2008-2010 John Smith",
+      "licenseComments" : "The concluded license was taken from package xyz, from which the snippet was copied into the current file. The concluded license information was found in the COPYING.txt file in package xyz.",
+      "licenseConcluded" : "GPL-2.0-only",
+      "licenseInfoInSnippets" : [ "GPL-2.0-only" ],
+      "name" : "from linux kernel",
+      "ranges" : [ {
+        "endPointer" : {
+          "offset" : 420,
+          "reference" : "SPDXRef-DoapSource"
+        },
+        "startPointer" : {
+          "offset" : 310,
+          "reference" : "SPDXRef-DoapSource"
+        }
+      }, {
+        "endPointer" : {
+          "lineNumber" : 23,
+          "reference" : "SPDXRef-DoapSource"
+        },
+        "startPointer" : {
+          "lineNumber" : 5,
+          "reference" : "SPDXRef-DoapSource"
+        }
+      } ],
+      "snippetFromFile" : "SPDXRef-DoapSource"
+    } ],
+    "relationships" : [ {
+      "spdxElementId" : "SPDXRef-DOCUMENT",
+      "relationshipType" : "CONTAINS",
+      "relatedSpdxElement" : "SPDXRef-Package"
+    }, {
+      "spdxElementId" : "SPDXRef-DOCUMENT",
+      "relationshipType" : "COPY_OF",
+      "relatedSpdxElement" : "DocumentRef-spdx-tool-1.2:SPDXRef-ToolsElement"
+    }, {
+      "spdxElementId" : "SPDXRef-Package",
+      "relationshipType" : "DYNAMIC_LINK",
+      "relatedSpdxElement" : "SPDXRef-Saxon"
+    }, {
+      "spdxElementId" : "SPDXRef-CommonsLangSrc",
+      "relationshipType" : "GENERATED_FROM",
+      "relatedSpdxElement" : "NOASSERTION"
+    }, {
+      "spdxElementId" : "SPDXRef-JenaLib",
+      "relationshipType" : "CONTAINS",
+      "relatedSpdxElement" : "SPDXRef-Package"
+    }, {
+      "spdxElementId" : "SPDXRef-Specification",
+      "relationshipType" : "SPECIFICATION_FOR",
+      "relatedSpdxElement" : "SPDXRef-fromDoap-0"
+    }, {
+      "spdxElementId" : "SPDXRef-File",
+      "relationshipType" : "GENERATED_FROM",
+      "relatedSpdxElement" : "SPDXRef-fromDoap-0"
+    } ]
+  }

--- a/tests/data/SPDXTagExample-v2.3.spdx
+++ b/tests/data/SPDXTagExample-v2.3.spdx
@@ -1,0 +1,338 @@
+SPDXVersion: SPDX-2.3
+DataLicense: CC0-1.0
+DocumentNamespace: http://spdx.org/spdxdocs/spdx-example-444504E0-4F89-41D3-9A0C-0305E82C3301
+DocumentName: SPDX-Tools-v2.0
+SPDXID: SPDXRef-DOCUMENT
+DocumentComment: <text>This document was created using SPDX 2.0 using licenses from the web site.</text>
+
+## External Document References
+ExternalDocumentRef: DocumentRef-spdx-tool-1.2 http://spdx.org/spdxdocs/spdx-tools-v1.2-3F2504E0-4F89-41D3-9A0C-0305E82C3301 SHA1: d6a770ba38583ed4bb4525bd96e50461655d2759
+## Creation Information
+Creator: Tool: LicenseFind-1.0
+Creator: Organization: ExampleCodeInspect ()
+Creator: Person: Jane Doe ()
+Created: 2010-01-29T18:30:22Z
+CreatorComment: <text>This package has been shipped in source and binary form.
+The binaries were created with gcc 4.5.1 and expect to link to
+compatible system run time libraries.</text>
+LicenseListVersion: 3.17
+## Annotations
+Annotator: Person: Jane Doe ()
+AnnotationDate: 2010-01-29T18:30:22Z
+AnnotationComment: <text>Document level annotation</text>
+AnnotationType: OTHER
+SPDXREF: SPDXRef-DOCUMENT
+Annotator: Person: Joe Reviewer
+AnnotationDate: 2010-02-10T00:00:00Z
+AnnotationComment: <text>This is just an example.  Some of the non-standard licenses look like they are actually BSD 3 clause licenses</text>
+AnnotationType: REVIEW
+SPDXREF: SPDXRef-DOCUMENT
+Annotator: Person: Suzanne Reviewer
+AnnotationDate: 2011-03-13T00:00:00Z
+AnnotationComment: <text>Another example reviewer.</text>
+AnnotationType: REVIEW
+SPDXREF: SPDXRef-DOCUMENT
+## Relationships
+Relationship: SPDXRef-DOCUMENT CONTAINS SPDXRef-Package
+Relationship: SPDXRef-DOCUMENT COPY_OF DocumentRef-spdx-tool-1.2:SPDXRef-ToolsElement
+Relationship: SPDXRef-DOCUMENT DESCRIBES SPDXRef-File
+Relationship: SPDXRef-DOCUMENT DESCRIBES SPDXRef-Package
+
+FileName: ./package/foo.c
+SPDXID: SPDXRef-File
+FileComment: <text>The concluded license was taken from the package level that the file was included in.
+This information was found in the COPYING.txt file in the xyz directory.</text>
+FileType: SOURCE
+FileChecksum: SHA1: d6a770ba38583ed4bb4525bd96e50461655d2758
+FileChecksum: MD5: 624c1abb3664f4b35547e7c73864ad24
+LicenseConcluded: (LGPL-2.0-only OR LicenseRef-2)
+LicenseInfoInFile: GPL-2.0-only
+LicenseInfoInFile: LicenseRef-2
+LicenseComments: The concluded license was taken from the package level that the file was included in.
+FileCopyrightText: <text>Copyright 2008-2010 John Smith</text>
+FileNotice: <text>Copyright (c) 2001 Aaron Lehmann aaroni@vitelus.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions: 
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</text>
+FileContributor: The Regents of the University of California
+FileContributor: Modified by Paul Mundt lethal@linux-sh.org
+FileContributor: IBM Corporation
+## Annotations
+Annotator: Person: File Commenter
+AnnotationDate: 2011-01-29T18:30:22Z
+AnnotationComment: <text>File level annotation</text>
+AnnotationType: OTHER
+SPDXREF: SPDXRef-File
+## Relationships
+Relationship: SPDXRef-File GENERATED_FROM SPDXRef-fromDoap-0
+## Package Information
+PackageName: glibc
+SPDXID: SPDXRef-Package
+PackageVersion: 2.11.1
+PackageFileName: glibc-2.11.1.tar.gz
+PackageSupplier: Person: Jane Doe (jane.doe@example.com)
+PackageOriginator: Organization: ExampleCodeInspect (contact@example.com)
+PackageDownloadLocation: http://ftp.gnu.org/gnu/glibc/glibc-ports-2.15.tar.gz
+PackageVerificationCode: d6a770ba38583ed4bb4525bd96e50461655d2758(./package.spdx)
+PackageChecksum: MD5: 624c1abb3664f4b35547e7c73864ad24
+PackageChecksum: SHA1: 85ed0817af83a24ad8da68c2b5094de69833983c
+PackageChecksum: SHA256: 11b6d3ee554eedf79299905a98f9b9a04e498210b59f15094c916c91d150efcd
+PackageChecksum: BLAKE2b-384: aaabd89c926ab525c242e6621f2f5fa73aa4afe3d9e24aed727faaadd6af38b620bdb623dd2b4788b1c8086984af8706
+PackageHomePage: http://ftp.gnu.org/gnu/glibc
+PackageSourceInfo: <text>uses glibc-2_11-branch from git://sourceware.org/git/glibc.git.</text>
+PrimaryPackagePurpose: SOURCE
+BuiltDate: 2011-01-29T18:30:22Z
+ReleaseDate: 2012-01-29T18:30:22Z
+ValidUntilDate: 2014-01-29T18:30:22Z
+PackageLicenseConcluded: (LGPL-2.0-only OR LicenseRef-3)
+## License information from files
+PackageLicenseInfoFromFiles: GPL-2.0-only
+PackageLicenseInfoFromFiles: LicenseRef-2
+PackageLicenseInfoFromFiles: LicenseRef-1
+PackageLicenseDeclared: (LGPL-2.0-only AND LicenseRef-3)
+PackageLicenseComments: <text>The license for this project changed with the release of version x.y.  The version of the project included here post-dates the license change.</text>
+PackageCopyrightText: <text>Copyright 2008-2010 John Smith</text>
+PackageSummary: <text>GNU C library.</text>
+PackageDescription: <text>The GNU C Library defines functions that are specified by the ISO C standard, as well as additional features specific to POSIX and other derivatives of the Unix operating system, and extensions specific to GNU systems.</text>
+PackageAttributionText: <text>The GNU C Library is free software.  See the file COPYING.LIB for copying conditions, and LICENSES for notices about a few contributions that require these additional notices to be distributed.  License copyright years may be listed using range notation, e.g., 1996-2015, indicating that every year in the range, inclusive, is a copyrightable year that would otherwise be listed individually.</text>
+ExternalRef: SECURITY cpe23Type cpe:2.3:a:pivotal_software:spring_framework:4.1.0:*:*:*:*:*:*:*
+ExternalRef: OTHER LocationRef-acmeforge acmecorp/acmenator/4.1.3-alpha
+ExternalRefComment: This is the external ref for Acme
+## Annotations
+Annotator: Person: Package Commenter
+AnnotationDate: 2011-01-29T18:30:22Z
+AnnotationComment: <text>Package level annotation</text>
+AnnotationType: OTHER
+SPDXREF: SPDXRef-Package
+## Relationships
+Relationship: SPDXRef-Package CONTAINS SPDXRef-JenaLib
+Relationship: SPDXRef-Package DYNAMIC_LINK SPDXRef-Saxon
+
+## File Information
+FileName: ./docs/myspec.pdf
+SPDXID: SPDXRef-Specification
+FileComment: <text>Specification Documentation</text>
+FileType: DOCUMENTATION
+FileChecksum: SHA1: fff4e1c67a2d28fced849ee1bb76e7391b93f125
+Relationship: SPDXRef-Specification SPECIFICATION_FOR SPDXRef-fromDoap-0
+
+## File Information
+FileName: ./lib-source/commons-lang3-3.1-sources.jar
+SPDXID: SPDXRef-CommonsLangSrc
+FileComment: <text>This file is used by Jena</text>
+FileType: ARCHIVE
+FileChecksum: SHA1: c2b4e1c67a2d28fced849ee1bb76e7391b93f125
+LicenseConcluded: Apache-2.0
+LicenseInfoInFile: Apache-2.0
+FileCopyrightText: <text>Copyright 2001-2011 The Apache Software Foundation</text>
+FileNotice: <text>Apache Commons Lang
+Copyright 2001-2011 The Apache Software Foundation
+
+This product includes software developed by
+The Apache Software Foundation (http://www.apache.org/).
+
+This product includes software from the Spring Framework,
+under the Apache License 2.0 (see: StringUtils.containsWhitespace())</text>
+FileContributor: Apache Software Foundation
+## Relationships
+Relationship: SPDXRef-CommonsLangSrc GENERATED_FROM NOASSERTION
+
+FileName: ./lib-source/jena-2.6.3-sources.jar
+SPDXID: SPDXRef-JenaLib
+FileComment: <text>This file belongs to Jena</text>
+FileType: ARCHIVE
+FileChecksum: SHA1: 3ab4e1c67a2d28fced849ee1bb76e7391b93f125
+LicenseConcluded: LicenseRef-1
+LicenseInfoInFile: LicenseRef-1
+LicenseComments: This license is used by Jena
+FileCopyrightText: <text>(c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP</text>
+FileContributor: Apache Software Foundation
+FileContributor: Hewlett Packard Inc.
+## Relationships
+Relationship: SPDXRef-JenaLib CONTAINS SPDXRef-Package
+
+FileName: ./src/org/spdx/parser/DOAPProject.java
+SPDXID: SPDXRef-DoapSource
+FileType: SOURCE
+FileChecksum: SHA1: 2fd4e1c67a2d28fced849ee1bb76e7391b93eb12
+LicenseConcluded: Apache-2.0
+LicenseInfoInFile: Apache-2.0
+FileCopyrightText: <text>Copyright 2010, 2011 Source Auditor Inc.</text>
+FileContributor: Protecode Inc.
+FileContributor: SPDX Technical Team Members
+FileContributor: Open Logic Inc.
+FileContributor: Source Auditor Inc.
+FileContributor: Black Duck Software In.c
+
+## Package Information
+PackageName: Apache Commons Lang
+SPDXID: SPDXRef-fromDoap-1
+PackageDownloadLocation: NOASSERTION
+PackageHomePage: http://commons.apache.org/proper/commons-lang/
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NOASSERTION
+FilesAnalyzed: false
+
+## Package Information
+PackageName: Jena
+SPDXID: SPDXRef-fromDoap-0
+PackageVersion: 3.12.0
+PackageDownloadLocation: https://search.maven.org/remotecontent?filepath=org/apache/jena/apache-jena/3.12.0/apache-jena-3.12.0.tar.gz
+PackageHomePage: http://www.openjena.org/
+ExternalRef: PACKAGE-MANAGER purl pkg:maven/org.apache.jena/apache-jena@3.12.0
+FilesAnalyzed: false
+
+## Package Information
+PackageName: Saxon
+SPDXID: SPDXRef-Saxon
+PackageVersion: 8.8
+PackageFileName: saxonB-8.8.zip
+PackageDownloadLocation: https://sourceforge.net/projects/saxon/files/Saxon-B/8.8.0.7/saxonb8-8-0-7j.zip/download
+PackageChecksum: SHA1: 85ed0817af83a24ad8da68c2b5094de69833983c
+PackageHomePage: http://saxon.sourceforge.net/
+PackageLicenseConcluded: MPL-1.0
+PackageLicenseDeclared: MPL-1.0
+PackageLicenseComments: <text>Other versions available for a commercial license</text>
+PackageCopyrightText: <text>Copyright Saxonica Ltd</text>
+PackageDescription: <text>The Saxon package is a collection of tools for processing XML documents.</text>
+FilesAnalyzed: false
+
+## Snippet Information
+SnippetSPDXID: SPDXRef-Snippet
+SnippetFromFileSPDXID: SPDXRef-DoapSource
+SnippetByteRange: 310:420
+SnippetLineRange: 5:23
+SnippetLicenseConcluded: GPL-2.0-only
+LicenseInfoInSnippet: GPL-2.0-only
+SnippetLicenseComments: The concluded license was taken from package xyz, from which the snippet was copied into the current file. The concluded license information was found in the COPYING.txt file in package xyz.
+SnippetCopyrightText: Copyright 2008-2010 John Smith
+SnippetComment: This snippet was identified as significant and highlighted in this Apache-2.0 file, when a commercial scanner identified it as being derived from file foo.c in package xyz which is licensed under GPL-2.0.
+SnippetName: from linux kernel
+
+
+## License Information
+LicenseID: LicenseRef-1
+ExtractedText: <text>/*
+ * (c) Copyright 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009 Hewlett-Packard Development Company, LP
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/</text>
+
+LicenseID: LicenseRef-2
+ExtractedText: <text>This package includes the GRDDL parser developed by Hewlett Packard under the following license:
+© Copyright 2007 Hewlett-Packard Development Company, LP
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: 
+
+Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. 
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution. 
+The name of the author may not be used to endorse or promote products derived from this software without specific prior written permission. 
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</text>
+
+LicenseID: LicenseRef-4
+ExtractedText: <text>/*
+ * (c) Copyright 2009 University of Bristol
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The name of the author may not be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/</text>
+
+LicenseID: LicenseRef-Beerware-4.2
+ExtractedText: <text>"THE BEER-WARE LICENSE" (Revision 42):
+phk@FreeBSD.ORG wrote this file. As long as you retain this notice you
+can do whatever you want with this stuff. If we meet some day, and you think this stuff is worth it, you can buy me a beer in return Poul-Henning Kamp</text>
+LicenseName: Beer-Ware License (Version 42)
+LicenseCrossReference:  http://people.freebsd.org/~phk/
+LicenseComment: The beerware license has a couple of other standard variants.
+
+LicenseID: LicenseRef-3
+ExtractedText: <text>The CyberNeko Software License, Version 1.0
+
+ 
+(C) Copyright 2002-2005, Andy Clark.  All rights reserved.
+ 
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer. 
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in
+   the documentation and/or other materials provided with the
+   distribution.
+
+3. The end-user documentation included with the redistribution,
+   if any, must include the following acknowledgment:  
+     "This product includes software developed by Andy Clark."
+   Alternately, this acknowledgment may appear in the software itself,
+   if and wherever such third-party acknowledgments normally appear.
+
+4. The names "CyberNeko" and "NekoHTML" must not be used to endorse
+   or promote products derived from this software without prior 
+   written permission. For written permission, please contact 
+   andyc@cyberneko.net.
+
+5. Products derived from this software may not be called "CyberNeko",
+   nor may "CyberNeko" appear in their name, without prior written
+   permission of the author.
+
+THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR OTHER CONTRIBUTORS
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, 
+OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT 
+OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR 
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE 
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, 
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</text>
+LicenseName: CyberNeko License
+LicenseCrossReference: http://people.apache.org/~andyc/neko/LICENSE, http://justasample.url.com
+LicenseComment: <text>This is tye CyperNeko License</text>

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2,30 +2,57 @@
 //
 // SPDX-License-Identifier: MIT
 
+use anyhow::Error;
+use anyhow::Result;
+use serde::de::DeserializeOwned;
+use serde_json::from_str as json_from_str;
+use serde_json::Error as SerdeJsonError;
+use spdx_rs::models::SPDX;
+use spdx_rs::parsers::spdx_from_tag_value;
 use std::fs::read_to_string;
-
-use spdx_rs::{error::SpdxError, models::SPDX, parsers::spdx_from_tag_value};
+use std::path::Path;
+use std::result::Result as StdResult;
 
 #[test]
-fn deserialize_json() -> Result<(), SpdxError> {
-    let spdx_file = read_to_string("tests/data/SPDXJSONExample-v2.2.spdx.json")?;
-    let spdx_document: SPDX = serde_json::from_str(&spdx_file).unwrap();
-
-    assert_eq!(
-        spdx_document.document_creation_information.spdx_identifier,
-        "SPDXRef-DOCUMENT"
-    );
-    Ok(())
+fn deserialize_json_v2_2() -> Result<()> {
+    Ok(load_spdx("tests/data/SPDXJSONExample-v2.2.spdx.json", spdx_from_json).map(ignore)?)
 }
 
 #[test]
-fn deserialize_tag_value() -> Result<(), SpdxError> {
-    let spdx_file = read_to_string("tests/data/SPDXTagExample-v2.2.spdx")?;
-    let spdx_document: SPDX = spdx_from_tag_value(&spdx_file)?;
+fn deserialize_json_v2_3() -> Result<()> {
+    Ok(load_spdx("tests/data/SPDXJSONExample-v2.3.spdx.json", spdx_from_json).map(ignore)?)
+}
 
-    assert_eq!(
-        spdx_document.document_creation_information.spdx_identifier,
-        "SPDXRef-DOCUMENT"
-    );
-    Ok(())
+#[test]
+fn deserialize_tag_value_v2_2() -> Result<()> {
+    Ok(load_spdx("tests/data/SPDXTagExample-v2.2.spdx", spdx_from_tag_value).map(ignore)?)
+}
+
+#[test]
+fn deserialize_tag_value_v2_3() -> Result<()> {
+    Ok(load_spdx("tests/data/SPDXTagExample-v2.3.spdx", spdx_from_tag_value).map(ignore)?)
+}
+
+/// Helper function for ignoring a value.
+fn ignore<T>(_: T) {
+    ()
+}
+
+/// Helper function which tightens the trait bounds on serde_json::from_str.
+fn spdx_from_json<T>(s: &str) -> StdResult<T, SerdeJsonError>
+where
+    T: DeserializeOwned,
+{
+    json_from_str(s)
+}
+
+/// Helper function to try calling the given parsing function on the contents of the given file.
+fn load_spdx<P, F, E>(path: P, parser: F) -> Result<SPDX, Error>
+where
+    P: AsRef<Path>,
+    F: FnOnce(&str) -> Result<SPDX, E>,
+    Error: From<E>,
+{
+    let result: SPDX = parser(&read_to_string(path.as_ref())?)?;
+    Ok(result)
 }


### PR DESCRIPTION
This commit introduces support for SPDX 2.3 documents, with the same underlying data type as 2.2 documents (all changes for 2.3 are backwards compatible, so no splitting of the data model is necessary).

This also includes additions of new tests for SPDX 2.3 documents.

---

Approved for Public Release; Distribution Unlimited. Case Number 23-1849.

©2023 The MITRE Corporation. All Rights Reserved.
