### PR TITLE
fix: accept complex license expression in 'LicenseInfoInFiles'

### DIFF
--- a/src/models/file_information.rs
+++ b/src/models/file_information.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: MIT
 
 use serde::{Deserialize, Serialize};
-use spdx_expression::{SimpleExpression, SpdxExpression};
+use spdx_expression::SpdxExpression;
 
 use super::{Algorithm, Checksum};
 
@@ -42,7 +42,7 @@ pub struct FileInformation {
         skip_serializing_if = "Vec::is_empty",
         default
     )]
-    pub license_information_in_file: Vec<SimpleExpression>,
+    pub license_information_in_file: Vec<SpdxExpression>,
 
     /// <https://spdx.github.io/spdx-spec/4-file-information/#47-comments-on-license>
     #[serde(
@@ -265,7 +265,7 @@ mod test {
         .unwrap();
         assert_eq!(
             spdx.file_information[0].license_information_in_file,
-            vec![SimpleExpression::parse("Apache-2.0").unwrap()]
+            vec![SpdxExpression::parse("Apache-2.0").unwrap()]
         );
     }
     #[test]

--- a/src/parsers/mod.rs
+++ b/src/parsers/mod.rs
@@ -28,7 +28,7 @@
 use std::collections::HashSet;
 
 use chrono::{DateTime, Utc};
-use spdx_expression::{SimpleExpression, SpdxExpression};
+use spdx_expression::SpdxExpression;
 
 use crate::{
     error::SpdxError,
@@ -467,7 +467,7 @@ fn process_atom_for_files(
         Atom::LicenseInfoInFile(value) => {
             if let Some(file) = &mut file_in_progress {
                 file.license_information_in_file
-                    .push(SimpleExpression::parse(value).unwrap());
+                    .push(SpdxExpression::parse(value).unwrap());
             }
         }
         Atom::LicenseComments(value) => {
@@ -934,8 +934,8 @@ This information was found in the COPYING.txt file in the xyz directory.".to_str
         assert_eq!(
             fooc.license_information_in_file,
             vec![
-                SimpleExpression::parse("GPL-2.0-only").unwrap(),
-                SimpleExpression::parse("LicenseRef-2").unwrap()
+                SpdxExpression::parse("GPL-2.0-only").unwrap(),
+                SpdxExpression::parse("LicenseRef-2").unwrap()
             ]
         );
         assert_eq!(fooc.comments_on_license, Some("The concluded license was taken from the package level that the file was included in.".to_string()));


### PR DESCRIPTION
[SPDX 2.3 documents](https://spdx.github.io/spdx-spec/v2.3/file-information/#86-license-information-in-file-field) explicitly allow complex expressions in the `LicenceInfoInFiles` field.
For SPDX 2.2 documents the spec is ambigous.

A discussion of the change in the spec can be found in https://github.com/spdx/spdx-spec/issues/760