### PR TITLE
Allow cloning the document

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 
 /target
 Cargo.lock
+
+.idea/

--- a/src/models/spdx_document.rs
+++ b/src/models/spdx_document.rs
@@ -37,7 +37,7 @@ use super::{
 /// [Serde]: https://serde.rs
 /// [review information]: https://spdx.github.io/spdx-spec/review-information-deprecated/
 /// [tag-value format]: https://spdx.github.io/spdx-spec/conformance/
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct SPDX {
     /// <https://spdx.github.io/spdx-spec/2-document-creation-information/>


### PR DESCRIPTION
Sometimes it is just necessary to clone the document.

Also, ignore IntelliJ project files.