### PR TITLE
fix: follow enum literals from schema

### DIFF
--- a/src/models/package_information.rs
+++ b/src/models/package_information.rs
@@ -299,13 +299,15 @@ impl ExternalPackageReference {
 #[serde(rename_all = "SCREAMING-KEBAB-CASE")]
 pub enum ExternalPackageReferenceCategory {
     Security,
+    #[serde(alias = "PACKAGE_MANAGER")]
     PackageManager,
+    #[serde(alias = "PERSISTENT_ID")]
     PersistentID,
     Other,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Copy)]
-#[serde(rename_all = "SCREAMING-KEBAB-CASE")]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum PrimaryPackagePurpose {
     Application,
     Framework,


### PR DESCRIPTION
Also see:
* https://github.com/spdx/spdx-spec/blob/844144b3785dbc6a35065eda3b9d36adda874540/schemas/spdx-schema.json#L328
* https://github.com/spdx/spdx-spec/blob/844144b3785dbc6a35065eda3b9d36adda874540/schemas/spdx-schema.json#L416C140-L416C156