### PR TITLE
Fix date parsing

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: 2023, Rylie Pavlik
+#
+# SPDX-License-Identifier: MIT
+
+Rylie Pavlik <rylie.pavlik@collabora.com>
+Rylie Pavlik <rylie.pavlik@collabora.com> <ryan.pavlik@collabora.com>
+

--- a/src/models/document_creation_information.rs
+++ b/src/models/document_creation_information.rs
@@ -250,9 +250,9 @@ mod test {
                 .creation_info
                 .creator_comment,
             Some(
-                r#"This package has been shipped in source and binary form.
+                r"This package has been shipped in source and binary form.
 The binaries were created with gcc 4.5.1 and expect to link to
-compatible system run time libraries."#
+compatible system run time libraries."
                     .to_string()
             )
         );

--- a/src/models/spdx_document.rs
+++ b/src/models/spdx_document.rs
@@ -72,7 +72,7 @@ pub struct SPDX {
     #[serde(default)]
     pub annotations: Vec<Annotation>,
 
-    /// Counter for creating SPDXRefs. Is not part of the spec, so don't serialize.
+    /// Counter for creating `SPDXRefs`. Is not part of the spec, so don't serialize.
     #[serde(skip)]
     pub spdx_ref_counter: i32,
 }

--- a/src/parsers/mod.rs
+++ b/src/parsers/mod.rs
@@ -614,11 +614,11 @@ fn process_atom_for_relationships(
 
 #[derive(Debug, Default)]
 struct AnnotationInProgress {
-    annotator_in_progress: Option<String>,
-    date_in_progress: Option<DateTime<Utc>>,
-    comment_in_progress: Option<String>,
-    type_in_progress: Option<AnnotationType>,
-    spdxref_in_progress: Option<String>,
+    annotator: Option<String>,
+    date: Option<DateTime<Utc>>,
+    comment: Option<String>,
+    annotation_type: Option<AnnotationType>,
+    spdxref: Option<String>,
 }
 
 fn process_annotation(
@@ -627,11 +627,11 @@ fn process_annotation(
     annotations: &mut Vec<Annotation>,
 ) {
     if let AnnotationInProgress {
-        annotator_in_progress: Some(annotator),
-        date_in_progress: Some(date),
-        comment_in_progress: Some(comment),
-        type_in_progress: Some(annotation_type),
-        spdxref_in_progress: Some(spdxref),
+        annotator: Some(annotator),
+        date: Some(date),
+        comment: Some(comment),
+        annotation_type: Some(annotation_type),
+        spdxref: Some(spdxref),
     } = &mut annotation_in_progress
     {
         let annotation = Annotation::new(
@@ -642,11 +642,11 @@ fn process_annotation(
             comment.clone(),
         );
         *annotation_in_progress = AnnotationInProgress {
-            annotator_in_progress: None,
-            comment_in_progress: None,
-            date_in_progress: None,
-            spdxref_in_progress: None,
-            type_in_progress: None,
+            annotator: None,
+            comment: None,
+            date: None,
+            spdxref: None,
+            annotation_type: None,
         };
         annotations.push(annotation);
     }
@@ -661,19 +661,19 @@ fn process_atom_for_annotations(
 
     match atom {
         Atom::Annotator(value) => {
-            annotation_in_progress.annotator_in_progress = Some(value.clone());
+            annotation_in_progress.annotator = Some(value.clone());
         }
         Atom::AnnotationDate(value) => {
-            annotation_in_progress.date_in_progress = Some(parse_date_time(value)?);
+            annotation_in_progress.date = Some(parse_date_time(value)?);
         }
         Atom::AnnotationComment(value) => {
-            annotation_in_progress.comment_in_progress = Some(value.clone());
+            annotation_in_progress.comment = Some(value.clone());
         }
         Atom::AnnotationType(value) => {
-            annotation_in_progress.type_in_progress = Some(*value);
+            annotation_in_progress.annotation_type = Some(*value);
         }
         Atom::SPDXREF(value) => {
-            annotation_in_progress.spdxref_in_progress = Some(value.clone());
+            annotation_in_progress.spdxref = Some(value.clone());
         }
         _ => {}
     }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -15,22 +15,22 @@ use std::result::Result as StdResult;
 
 #[test]
 fn deserialize_json_v2_2() -> Result<()> {
-    Ok(load_spdx("tests/data/SPDXJSONExample-v2.2.spdx.json", spdx_from_json).map(ignore)?)
+    load_spdx("tests/data/SPDXJSONExample-v2.2.spdx.json", spdx_from_json).map(ignore)
 }
 
 #[test]
 fn deserialize_json_v2_3() -> Result<()> {
-    Ok(load_spdx("tests/data/SPDXJSONExample-v2.3.spdx.json", spdx_from_json).map(ignore)?)
+    load_spdx("tests/data/SPDXJSONExample-v2.3.spdx.json", spdx_from_json).map(ignore)
 }
 
 #[test]
 fn deserialize_tag_value_v2_2() -> Result<()> {
-    Ok(load_spdx("tests/data/SPDXTagExample-v2.2.spdx", spdx_from_tag_value).map(ignore)?)
+    load_spdx("tests/data/SPDXTagExample-v2.2.spdx", spdx_from_tag_value).map(ignore)
 }
 
 #[test]
 fn deserialize_tag_value_v2_3() -> Result<()> {
-    Ok(load_spdx("tests/data/SPDXTagExample-v2.3.spdx", spdx_from_tag_value).map(ignore)?)
+    load_spdx("tests/data/SPDXTagExample-v2.3.spdx", spdx_from_tag_value).map(ignore)
 }
 
 /// Helper function for ignoring a value.


### PR DESCRIPTION
Apparently REUSE has started outputting dates in a way that Chrono does not like (offset as well as trailing Z). I implemented a little helper, kind of gross but it works.

I also added a mailmap file to update my name in the git history.

It needed a little clippy love to pass CI, too.