### PR TITLE
chore: bump strum_macros from 0.25 to 0.27

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ log = "0.4"
 uuid = { version = "1", features = ["v4"] }
 chrono = { version = "0.4", default-features = false, features = ["clock", "serde"] }
 thiserror = "1"
-strum_macros = "0.25"
+strum_macros = "0.27"
 spdx-expression = "0.5.2"
 nom = "7"
 


### PR DESCRIPTION
To update the dependency of `heck` from 0.4 to 0.5.